### PR TITLE
Freeze Django version to 1.8.x.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 install_requires = [
-    'django',
+    'django >=1.8, <1.9',
 ]
 
 version = __import__('django_medusa').get_version()


### PR DESCRIPTION
This prevents django-medusa from installing django 1.9
